### PR TITLE
LIBFCREPO-1137. Added unit tests for OAI-PMH server.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.egg-info
+.coverage
 .env
 .venv

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ OAI-PMH Server for Fedora
 
 ## Purpose
 
+This is an [OAI-PMH] server for publishing metadata records from a Fedora 
+repository. It uses a Solr index for general queries, and connects 
+directly to Fedora to retrieve the full metadata record for an item.
+
 ## Development Environment
 
 Python version: 3.11
@@ -15,7 +19,7 @@ git clone git@github.com:umd-lib/umd-fcrepo-oaipmh.git
 cd umd-fcrepo-oaipmh
 pyenv install --skip-existing $(cat .python-version)
 python -m venv .venv --prompt umd-fcrepo-oaipmh-py$(cat .python-version)
-pip install -r requirements.txt -e .
+pip install -r test.requirements.txt -e .
 ```
 
 ### Configuration
@@ -53,3 +57,31 @@ To change the port, add `-p {port number}` to the `flask` command:
 # for example, to run on port 8000
 flask --app oaipmh.web:app run -p 8000
 ```
+
+### Testing
+
+This project uses the [pytest] testing framework. To run the full
+[test suite](tests):
+
+```bash
+pytest
+```
+
+To run the test suite with coverage information from [pytest-cov]:
+
+```bash
+pytest --cov src --cov-report term-missing
+```
+
+This project also uses [pycodestyle] as a style checker and linter:
+
+```bash
+pycodestyle src
+```
+
+Configuration of pycodestyle is found in the [tox.ini](tox.ini) file.
+
+[OAI-PMH]: https://www.openarchives.org/pmh/
+[pytest]: https://docs.pytest.org/en/7.3.x/
+[pytest-cov]: https://pypi.org/project/pytest-cov/
+[pycodestyle]: https://pycodestyle.pycqa.org/en/latest/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,8 @@ dependencies = [
     "requests",
     "requests-jwtauth@git+https://github.com/umd-lib/requests-jwtauth.git@1.0.0",
 ]
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-cov",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
 ]
 [project.optional-dependencies]
 test = [
+    "pycodestyle",
     "pytest",
     "pytest-cov",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ pycparser==2.21
 pysolr==3.9.0
 python-dotenv==1.0.0
 requests==2.30.0
-requests-jwtauth @ git+https://github.com/umd-lib/requests-jwtauth.git@5ed903865615beb9746104e68dcdfa59bbb67d48
+requests-jwtauth @ git+https://github.com/umd-lib/requests-jwtauth.git@1.0.0
 six==1.16.0
 urllib3==2.0.2
 validators==0.20.0

--- a/src/oaipmh/dataprovider.py
+++ b/src/oaipmh/dataprovider.py
@@ -3,9 +3,10 @@ import os
 import re
 import urllib.parse
 from collections.abc import Iterable
+from dataclasses import MISSING
 from datetime import datetime
 from email.utils import parsedate_to_datetime
-from typing import Optional
+from typing import Optional, Any
 
 import pysolr
 from lxml import etree
@@ -21,14 +22,6 @@ from oaipmh.transformers import load_transformers
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
-
-BASE_URL = os.environ.get('BASE_URL', 'http://localhost:5000/')
-ADMIN_EMAIL = os.environ.get('ADMIN_EMAIL')
-DATESTAMP_GRANULARITY = os.environ.get('DATESTAMP_GRANULARITY', 'YYYY-MM-DDThh:mm:ssZ')
-EARLIEST_DATESTAMP = os.environ.get('EARLIEST_DATESTAMP')
-PAGE_SIZE = os.environ.get('PAGE_SIZE', 25)
-OAI_REPOSITORY_NAME = os.environ.get('OAI_REPOSITORY_NAME')
-REPORT_DELETED_RECORDS = os.environ.get('REPORT_DELETED_RECORDS', 'no')
 
 BASE_QUERY = 'rdf_type:pcdm\\:Object AND component:* NOT component:Page NOT component:Article'
 SETS = {}
@@ -53,8 +46,40 @@ class OAIIdentifier:
         return f'oai:{self.namespace_identifier}:{urllib.parse.quote(self.local_identifier)}'
 
 
+class EnvAttribute:
+    """
+    Descriptor class that maps an attribute of a class to an environment variable.
+    """
+    def __init__(self, env_var: str, default: Optional[Any] = MISSING):
+        self.env_var = env_var
+        self.default = default
+
+    def __set_name__(self, owner, name):
+        self.name = name
+
+    def __get__(self, instance, owner):
+        if self.default is not MISSING:
+            value = os.environ.get(self.env_var, self.default)
+        else:
+            value = os.environ.get(self.env_var)
+
+        # if this attribute has a type annotation, use it to cast the
+        # string value from the environment variable to some other type
+        if self.name in instance.__annotations__:
+            return instance.__annotations__[self.name](value)
+        else:
+            return value
+
+
 class DataProvider(DataInterface):
-    limit = PAGE_SIZE
+    admin_email = EnvAttribute('ADMIN_EMAIL')
+    base_url = EnvAttribute('BASE_URL', 'http://localhost:5000/')
+    datestamp_granularity = EnvAttribute('DATESTAMP_GRANULARITY', 'YYYY-MM-DDThh:mm:ssZ')
+    earliest_datestamp = EnvAttribute('EARLIEST_DATESTAMP')
+    oai_repository_name = EnvAttribute('OAI_REPOSITORY_NAME')
+    oai_namespace_identifier = EnvAttribute('OAI_NAMESPACE_IDENTIFIER')
+    report_deleted_records = EnvAttribute('REPORT_DELETED_RECORDS', 'no')
+    limit: int = EnvAttribute('PAGE_SIZE', 25)
 
     def __init__(self, solr_client: pysolr.Solr):
         self.solr = solr_client
@@ -65,6 +90,13 @@ class DataProvider(DataInterface):
         self._transformers = load_transformers()
         self.sets = {s.spec: s for s in get_sets(get_collection_titles(self.solr))}
 
+    # XXX: use the URI as a stopgap until handles are implemented for fcrepo
+    def get_oai_identifier(self, local_identifier: str) -> OAIIdentifier:
+        return OAIIdentifier(
+            namespace_identifier=self.oai_namespace_identifier,
+            local_identifier=local_identifier,
+        )
+
     def transform(self, target_format: str, xml_root: _Element) -> _Element:
         try:
             transform = self._transformers[target_format]
@@ -74,16 +106,16 @@ class DataProvider(DataInterface):
 
     def get_identify(self) -> Identify:
         return Identify(
-            base_url=BASE_URL,
-            admin_email=[ADMIN_EMAIL],
-            repository_name=OAI_REPOSITORY_NAME,
-            earliest_datestamp=EARLIEST_DATESTAMP,
-            deleted_record=REPORT_DELETED_RECORDS,
-            granularity=DATESTAMP_GRANULARITY,
+            base_url=self.base_url,
+            admin_email=[self.admin_email],
+            repository_name=self.oai_repository_name,
+            earliest_datestamp=self.earliest_datestamp,
+            deleted_record=self.report_deleted_records,
+            granularity=self.datestamp_granularity,
         )
 
     def is_valid_identifier(self, identifier: str) -> bool:
-        return identifier.startswith(f'oai:{os.environ.get("OAI_NAMESPACE_IDENTIFIER")}:')
+        return identifier.startswith(f'oai:{self.oai_namespace_identifier}:')
 
     def get_metadata_formats(self, identifier: str | None = None) -> list[MetadataFormat]:
         return [transformer.metadata_format for transformer in self._transformers.values()]
@@ -96,7 +128,7 @@ class DataProvider(DataInterface):
             last_modified = parsedate_to_datetime(response.headers['Last-Modified'])
         return RecordHeader(
             identifier=identifier,
-            datestamp=granularity_format(DATESTAMP_GRANULARITY, last_modified),
+            datestamp=granularity_format(self.datestamp_granularity, last_modified),
             # TODO: include setSpec elements
         )
 
@@ -152,17 +184,9 @@ class DataProvider(DataInterface):
             results = self.solr.search(q='*:*', fq=filter_query, start=cursor, rows=self.limit)
         except pysolr.SolrError as e:
             raise OAIRepoExternalException('Unable to connect to Solr') from e
-        self.solr_results = {str(get_oai_identifier(doc['id'])): doc for doc in results}
+        self.solr_results = {str(self.get_oai_identifier(doc['id'])): doc for doc in results}
         identifiers = list(self.solr_results.keys())
         return identifiers, results.hits, None
-
-
-# XXX: use the URI as a stopgap until handles are implemented for fcrepo
-def get_oai_identifier(local_identifier: str) -> OAIIdentifier:
-    return OAIIdentifier(
-        namespace_identifier=os.environ.get('OAI_NAMESPACE_IDENTIFIER'),
-        local_identifier=local_identifier,
-    )
 
 
 def get_solr_date_range(timestamp_from: Optional[datetime], timestamp_until: Optional[datetime]) -> str:

--- a/src/oaipmh/transformers/oai_dc.xsl
+++ b/src/oaipmh/transformers/oai_dc.xsl
@@ -9,6 +9,7 @@
                 xmlns:rel="http://id.loc.gov/vocabulary/relators/"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+  <xsl:strip-space elements="*"/>
 
   <xsl:template match="text()"/>
 

--- a/src/oaipmh/transformers/rdf.xsl
+++ b/src/oaipmh/transformers/rdf.xsl
@@ -1,11 +1,14 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                xmlns:fedora="http://fedora.info/definitions/v4/repository#"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xsi:schemaLocation="http://www.w3.org/1999/02/22-rdf-syntax-ns# http://www.openarchives.org/OAI/2.0/rdf.xsd">
-  <xsl:template match="/rdf:RDF">
+  <xsl:strip-space elements="*"/>
+
+  <xsl:template match="/">
     <rdf:RDF xsi:schemaLocation="http://www.w3.org/1999/02/22-rdf-syntax-ns# http://www.openarchives.org/OAI/2.0/rdf.xsd">
       <xsl:copy-of select="@*"/>
-      <xsl:apply-templates/>
+      <xsl:apply-templates select="rdf:RDF/rdf:Description"/>
     </rdf:RDF>
   </xsl:template>
 
@@ -14,4 +17,7 @@
       <xsl:apply-templates select="@*|node()"/>
     </xsl:copy>
   </xsl:template>
+
+  <!-- skip the fedora:writable element -->
+  <xsl:template match="fedora:writable"/>
 </xsl:stylesheet>

--- a/src/oaipmh/web.py
+++ b/src/oaipmh/web.py
@@ -1,6 +1,7 @@
 import os
 from http import HTTPStatus
 
+import pysolr
 from flask import Flask, request, abort
 from oai_repo import OAIRepository, OAIRepoInternalException, OAIRepoExternalException
 from oai_repo.response import OAIResponse
@@ -29,7 +30,7 @@ def status(response: OAIResponse) -> int:
 @app.route('/oai')
 def endpoint():
     try:
-        repo = OAIRepository(DataProvider(solr_url=SOLR_URL))
+        repo = OAIRepository(DataProvider(solr_client=pysolr.Solr(SOLR_URL)))
         response = repo.process(request.args.copy())
     except OAIRepoExternalException as e:
         # An API call timed out or returned a non-200 HTTP code.

--- a/test.requirements.txt
+++ b/test.requirements.txt
@@ -3,6 +3,7 @@ coverage==7.2.7
 iniconfig==2.0.0
 packaging==23.1
 pluggy==1.0.0
+pycodestyle==2.10.0
 pytest==7.3.2
 pytest-cov==4.1.0
 pytest-datadir==1.4.1

--- a/test.requirements.txt
+++ b/test.requirements.txt
@@ -1,0 +1,8 @@
+-r requirements.txt
+coverage==7.2.7
+iniconfig==2.0.0
+packaging==23.1
+pluggy==1.0.0
+pytest==7.3.2
+pytest-cov==4.1.0
+pytest-datadir==1.4.1

--- a/tests/dataprovider/test_dataprovider.py
+++ b/tests/dataprovider/test_dataprovider.py
@@ -1,0 +1,84 @@
+from unittest.mock import MagicMock
+
+import pysolr
+import pytest
+from lxml import etree
+from oai_repo.exceptions import OAIErrorCannotDisseminateFormat
+
+from oaipmh.dataprovider import DataProvider, OAIIdentifier
+
+
+@pytest.fixture
+def mock_solr_client():
+    mock_solr = MagicMock(spec=pysolr.Solr)
+    mock_solr.url = 'http://localhost:8983/solr/fcrepo'
+    return mock_solr
+
+
+@pytest.fixture
+def provider(mock_solr_client):
+    return DataProvider(solr_client=mock_solr_client)
+
+
+@pytest.fixture
+def xml():
+    return etree.XML('<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>')
+
+
+@pytest.fixture
+def prange_rdf(datadir):
+    return etree.parse(datadir / 'prange_poster.xml')
+
+
+def test_dataprovider(monkeypatch, provider):
+    monkeypatch.setenv('OAI_NAMESPACE_IDENTIFIER', 'fcrepo')
+    assert provider.is_valid_identifier('oai:fcrepo:foo')
+    assert not provider.is_valid_identifier('oai:other:thing')
+
+
+def test_transform_unsupported_format(provider, xml):
+    with pytest.raises(OAIErrorCannotDisseminateFormat):
+        provider.transform('fake', xml)
+
+
+@pytest.mark.parametrize(
+    ('transformer', 'result_tag'),
+    [
+        ('oai_dc', '{http://www.openarchives.org/OAI/2.0/oai_dc/}dc'),
+        ('rdf', '{http://www.w3.org/1999/02/22-rdf-syntax-ns#}RDF'),
+    ]
+)
+def test_transform(provider, prange_rdf, transformer, result_tag):
+    result = provider.transform(transformer, prange_rdf)
+    assert result.tag == result_tag
+
+
+def test_get_metadata_formats(provider):
+    formats = provider.get_metadata_formats()
+    assert len(formats) == 2
+    assert {f.metadata_prefix for f in formats} == {'oai_dc', 'rdf'}
+
+
+@pytest.mark.parametrize(
+    ('local_identifier', 'expected'),
+    [
+        ('foo', 'oai:fcrepo:foo'),
+        ('http://fcrepo-local:8080/fcrepo/rest/bar', 'oai:fcrepo:http%3A//fcrepo-local%3A8080/fcrepo/rest/bar'),
+    ]
+)
+def test_get_oai_identifier(monkeypatch, provider, local_identifier, expected):
+    monkeypatch.setenv('OAI_NAMESPACE_IDENTIFIER', 'fcrepo')
+    identifier = provider.get_oai_identifier(local_identifier)
+    assert isinstance(identifier, OAIIdentifier)
+    assert str(identifier) == expected
+
+
+def test_get_record_header_from_solr_results(provider):
+    provider.solr_results = {
+        'oai:fcrepo:foo': {
+            'last_modified': '2023-06-16T08:37:29Z'
+        }
+    }
+    header = provider.get_record_header('oai:fcrepo:foo')
+    assert header.identifier == 'oai:fcrepo:foo'
+    assert header.datestamp == '2023-06-16T08:37:29Z'

--- a/tests/dataprovider/test_dataprovider/prange_poster.xml
+++ b/tests/dataprovider/test_dataprovider/prange_poster.xml
@@ -1,0 +1,53 @@
+<rdf:RDF
+        xmlns:geo="http://www.w3.org/2003/01/geo/wgs84_pos#"
+        xmlns:dcterms="http://purl.org/dc/terms/"
+        xmlns:dc="http://purl.org/dc/elements/1.1/"
+        xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        xmlns:iana="http://www.iana.org/assignments/relation/"
+        xmlns:edm="http://www.europeana.eu/schemas/edm/"
+        xmlns:fedora="http://fedora.info/definitions/v4/repository#"
+        xmlns:bibo="http://purl.org/ontology/bibo/"
+        xmlns:pcdm="http://pcdm.org/models#">
+  <rdf:Description rdf:about="https://fcrepo-test.lib.umd.edu/fcrepo/rest/pcdm/61/4f/aa/1c/614faa1c-2b15-4112-9a60-01a5a33a1c37">
+    <rdf:type rdf:resource="http://www.w3.org/ns/ldp#RDFSource"/>
+    <pcdm:memberOf rdf:resource="https://fcrepo-test.lib.umd.edu/fcrepo/rest/pcdm/9c/33/f7/f3/9c33f7f3-e275-4248-9c46-36666b28d704"/>
+    <iana:last rdf:resource="http://fedora.info/definitions/v4/repository#inaccessibleResource"/>
+    <edm:hasType>Newspapers</edm:hasType>
+    <edm:hasType rdf:resource="http://id.loc.gov/authorities/genreForms/gf2014026132.html"/>
+    <dc:language>Japanese</dc:language>
+    <fedora:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2022-04-11T17:38:46.055Z</fedora:created>
+    <dcterms:subject rdf:resource="http://id.loc.gov/authorities/subjects/sh85144914.html"/>
+    <dc:format>Newspapers, 74 x 52.3 cm.</dc:format>
+    <dcterms:type rdf:resource="http://purl.org/dc/dcmitype/Image"/>
+    <dcterms:isPartOf>Gordon W. Prange Collection</dcterms:isPartOf>
+    <rdf:type rdf:resource="http://vocab.lib.umd.edu/access#Public"/>
+    <fedora:writable rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</fedora:writable>
+    <dcterms:title xml:lang="ja">国民ニュース</dcterms:title>
+    <dcterms:identifier>prange-042754</dcterms:identifier>
+    <fedora:lastModifiedBy>plastron</fedora:lastModifiedBy>
+    <rdf:type rdf:resource="http://purl.org/ontology/bibo/Image"/>
+    <fedora:createdBy>plastron</fedora:createdBy>
+    <geo:lat>35.6895</geo:lat>
+    <dcterms:title xml:lang="ja-latn">Kokumin nyusu</dcterms:title>
+    <rdf:type rdf:resource="http://fedora.info/definitions/v4/repository#Container"/>
+    <dc:publisher xml:lang="ja">国際日報社</dc:publisher>
+    <dcterms:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dcterms:rights rdf:resource="http://rightsstatements.org/vocab/NoC-US/1.0/"/>
+    <fedora:lastModified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2022-04-11T17:38:46.055Z</fedora:lastModified>
+    <dc:type>image</dc:type>
+    <dc:coverage>Tokyo</dc:coverage>
+    <pcdm:hasMember rdf:resource="http://fedora.info/definitions/v4/repository#inaccessibleResource"/>
+    <dcterms:isPartOf xml:lang="ja">ゴードン W. プランゲ文庫</dcterms:isPartOf>
+    <dc:subject>Wall newspapers</dc:subject>
+    <bibo:locator>NZK32</bibo:locator>
+    <iana:first rdf:resource="http://fedora.info/definitions/v4/repository#inaccessibleResource"/>
+    <dc:publisher xml:lang="ja-latn">Kokusai Nipposha</dc:publisher>
+    <geo:long>139.69171</geo:long>
+    <fedora:hasParent rdf:resource="https://fcrepo-test.lib.umd.edu/fcrepo/rest/pcdm"/>
+    <rdf:type rdf:resource="http://pcdm.org/models#Object"/>
+    <rdf:type rdf:resource="http://www.w3.org/ns/ldp#Container"/>
+    <rdf:type rdf:resource="http://fedora.info/definitions/v4/repository#Resource"/>
+    <dc:coverage xml:lang="ja">東京</dc:coverage>
+    <dcterms:spatial rdf:resource="http://sws.geonames.org/1850144"/>
+  </rdf:Description>
+</rdf:RDF>

--- a/tests/dataprovider/test_functions.py
+++ b/tests/dataprovider/test_functions.py
@@ -5,8 +5,7 @@ import pysolr
 import pytest
 from oai_repo import Set
 
-from oaipmh.dataprovider import OAIIdentifier, get_solr_date_range, get_set_spec, get_sets, get_collection_titles, \
-    get_oai_identifier
+from oaipmh.dataprovider import get_solr_date_range, get_set_spec, get_sets, get_collection_titles
 
 
 @pytest.mark.parametrize(
@@ -73,17 +72,3 @@ def test_get_collection_titles():
     assert len(titles) == 2
     assert titles[0] == 'Foo'
     assert titles[1] == 'Bar'
-
-
-@pytest.mark.parametrize(
-    ('local_identifier', 'expected'),
-    [
-        ('foo', 'oai:fcrepo:foo'),
-        ('http://fcrepo-local:8080/fcrepo/rest/bar', 'oai:fcrepo:http%3A//fcrepo-local%3A8080/fcrepo/rest/bar'),
-    ]
-)
-def test_get_oai_identifier(monkeypatch, local_identifier, expected):
-    monkeypatch.setenv('OAI_NAMESPACE_IDENTIFIER', 'fcrepo')
-    identifier = get_oai_identifier(local_identifier)
-    assert isinstance(identifier, OAIIdentifier)
-    assert str(identifier) == expected

--- a/tests/dataprovider/test_functions.py
+++ b/tests/dataprovider/test_functions.py
@@ -1,0 +1,89 @@
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pysolr
+import pytest
+from oai_repo import Set
+
+from oaipmh.dataprovider import OAIIdentifier, get_solr_date_range, get_set_spec, get_sets, get_collection_titles, \
+    get_oai_identifier
+
+
+@pytest.mark.parametrize(
+    ('timestamp_from', 'timestamp_until', 'expected'),
+    [
+        (None, None, '[* TO *]'),
+        (datetime.fromisoformat('2023-06-15'), None, '[2023-06-15T00:00:00Z TO *]'),
+        (None, datetime.fromisoformat('2023-06-15'), '[* TO 2023-06-15T00:00:00Z]'),
+        (
+            datetime.fromisoformat('2023-01-31'),
+            datetime.fromisoformat('2023-06-15'),
+            '[2023-01-31T00:00:00Z TO 2023-06-15T00:00:00Z]',
+        ),
+    ]
+)
+def test_get_solr_date_range(timestamp_from, timestamp_until, expected):
+    date_range = get_solr_date_range(timestamp_from, timestamp_until)
+    assert date_range == expected
+
+
+@pytest.mark.parametrize(
+    ('timestamp_from', 'timestamp_until'),
+    [
+        ('not a date', 'also not'),
+        (datetime.fromisoformat('2023-06-16'), 'not a date'),
+        ('not a date', datetime.fromisoformat('2023-06-16')),
+        ('not a date', None),
+        (None, 'not a date'),
+    ]
+)
+def test_get_solr_date_range_invalid(timestamp_from, timestamp_until):
+    with pytest.raises(TypeError):
+        get_solr_date_range(timestamp_from, timestamp_until)
+
+
+@pytest.mark.parametrize(
+    ('title', 'expected'),
+    [
+        ('', ''),
+        ('Simple', 'simple'),
+        ('SOME Collection [#1]', 'some_collection_1_'),
+    ]
+)
+def test_get_set_spec(title, expected):
+    assert get_set_spec(title) == expected
+
+
+def test_get_sets():
+    titles = ['Katherine Anne Porter Correspondence', 'Punk Fanzines']
+    sets = get_sets(titles)
+    assert len(sets) == 2
+    assert isinstance(sets[0], Set)
+    assert sets[0].name == 'Katherine Anne Porter Correspondence'
+    assert sets[0].spec == 'katherine_anne_porter_correspondence'
+    assert isinstance(sets[1], Set)
+    assert sets[1].name == 'Punk Fanzines'
+    assert sets[1].spec == 'punk_fanzines'
+
+
+def test_get_collection_titles():
+    mock_solr = MagicMock(spec=pysolr.Solr)
+    mock_solr.search = MagicMock(return_value=[{'display_title': 'Foo'}, {'display_title': 'Bar'}])
+    titles = get_collection_titles(mock_solr)
+    assert len(titles) == 2
+    assert titles[0] == 'Foo'
+    assert titles[1] == 'Bar'
+
+
+@pytest.mark.parametrize(
+    ('local_identifier', 'expected'),
+    [
+        ('foo', 'oai:fcrepo:foo'),
+        ('http://fcrepo-local:8080/fcrepo/rest/bar', 'oai:fcrepo:http%3A//fcrepo-local%3A8080/fcrepo/rest/bar'),
+    ]
+)
+def test_get_oai_identifier(monkeypatch, local_identifier, expected):
+    monkeypatch.setenv('OAI_NAMESPACE_IDENTIFIER', 'fcrepo')
+    identifier = get_oai_identifier(local_identifier)
+    assert isinstance(identifier, OAIIdentifier)
+    assert str(identifier) == expected

--- a/tests/dataprovider/test_oaiidentifier.py
+++ b/tests/dataprovider/test_oaiidentifier.py
@@ -1,0 +1,23 @@
+import pytest
+
+from oaipmh.dataprovider import OAIIdentifier
+
+
+def test_oai_identifier_parse_invalid():
+    with pytest.raises(ValueError):
+        OAIIdentifier.parse('invalid:ident')
+
+
+@pytest.mark.parametrize(
+    ('identifier_string', 'namespace_identifier', 'local_identifier'),
+    [
+        ('oai:fcrepo:foo', 'fcrepo', 'foo'),
+        ('oai:fcrepo:http%3A//fcrepo-local%3A8080/rest/foo', 'fcrepo', 'http://fcrepo-local:8080/rest/foo'),
+    ]
+)
+def test_oai_identifier_parse(identifier_string, namespace_identifier, local_identifier):
+    identifier = OAIIdentifier.parse(identifier_string)
+    assert isinstance(identifier, OAIIdentifier)
+    assert identifier.namespace_identifier == namespace_identifier
+    assert identifier.local_identifier == local_identifier
+    assert str(identifier) == identifier_string

--- a/tests/transformers/test_transformer.py
+++ b/tests/transformers/test_transformer.py
@@ -1,0 +1,9 @@
+import pytest
+from oai_repo import OAIRepoInternalException
+
+from oaipmh.transformers import Transformer
+
+
+def test_bad_transformer(datadir):
+    with pytest.raises(OAIRepoInternalException):
+        Transformer(datadir / 'no_xsi-schemaLocation.xsl')

--- a/tests/transformers/test_transformer/no_xsi-schemaLocation.xsl
+++ b/tests/transformers/test_transformer/no_xsi-schemaLocation.xsl
@@ -1,0 +1,3 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <!-- invalid transformer XSLT; missing the xsi:schemaLocation -->
+</xsl:stylesheet>

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,3 @@
+[pycodestyle]
+max-line-length = 120
+statistics = True


### PR DESCRIPTION
- refactored DataProvider class to take a pysolr.Solr object instead of just a Solr URL
- read the OAI_NAMESPACE_IDENTIFIER environment variable at time of use
- raise a TypeError from get_solr_date_range() if it is unable to convert timestamps
- adjusted the XSL template matching in the rdf.xsl template to get the right nesting of rdf:RDF and rdf:Description elements in the output
- strip space from the output XML elements in the transformations
- created EnvAttribute class that maps an attribute of an object to an environment variable
- moved the get_oai_identifier() function into the DataProvider as a method
- added pycodestyle to the projcect
- updated README

https://umd-dit.atlassian.net/browse/LIBFCREPO-1137