### PR TITLE
LIBFCREPO-1139. Created Dockerfile for the application.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11.2-slim
+
+EXPOSE 5000
+
+WORKDIR /opt/umd-fcrepo-oaipmh
+
+# need git for the requests-jwtauth package to be installed from GitHub
+RUN apt-get update && apt-get install -y git && apt-get clean
+
+COPY requirements.txt /opt/umd-fcrepo-oaipmh/
+RUN pip install -r requirements.txt
+COPY src pyproject.toml /opt/umd-fcrepo-oaipmh/
+RUN pip install -e .
+
+CMD ["fcrepo-oaipmh-server"]

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To change the port, add `-p {port number}` to the `flask` command:
 
 ```bash
 # for example, to run on port 8000
-flask --app oaipmh.web:app run -p 8000
+flask --app oaipmh.web:create_app run -p 8000
 ```
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ OAI_REPOSITORY_NAME=...
 EARLIEST_DATESTAMP=2014-01-01T00:00:00Z
 # JWT bearer token for accessing the Fedora repository
 FCREPO_JWT_TOKEN=...
+# URL to the Solr core to search
+SOLR_URL=...
 # enable debugging and hot reloading when run via "flask run"
 FLASK_DEBUG=1
 ```
@@ -51,7 +53,15 @@ flask --app oaipmh.web:app run
 
 The application will be available at <http://localhost:5000/>
 
-To change the port, add `-p {port number}` to the `flask` command:
+To change the port, add a `BASE_URL` environment variable to the `.env` file:
+
+```bash
+# set when using a URL and/or port other than 
+# the defaults ("localhost" and "5000")
+BASE_URL=http://localhost:8000/
+```
+
+And add `-p {port number}` to the `flask` command:
 
 ```bash
 # for example, to run on port 8000
@@ -80,6 +90,53 @@ pycodestyle src
 ```
 
 Configuration of pycodestyle is found in the [tox.ini](tox.ini) file.
+
+### Deploying using Docker
+
+Build the image:
+
+```bash
+docker build -t docker.lib.umd.edu/fcrepo-oaipmh:latest .
+```
+
+If you need to build for multiple architectures (e.g., AMD and ARM), you 
+can use `docker buildx`. This assumes you have a builder named "local" 
+configured for use with your docker buildx system, and you are logged in 
+to a Docker repository that you can push images to:
+
+```bash
+docker buildx build --builder local --platform linux/amd64,linux/arm64 \
+    -t docker.lib.umd.edu/fcrepo-oaipmh:latest --push .
+    
+# then pull the image so it is available locally
+docker pull docker.lib.umd.edu/fcrepo-oaipmh:latest
+```
+
+Run the container:
+
+```bash
+docker run -d -p 5000:5000 \
+    -e ADMIN_EMAIL=... \
+    -e OAI_NAMESPACE_IDENTIFIER=... \
+    -e OAI_REPOSITORY_NAME=... \
+    -e EARLIEST_DATESTAMP=2014-01-01T00:00:00Z \
+    -e FCREPO_JWT_TOKEN=... \
+    -e SOLR_URL=... \
+    docker.lib.umd.edu/fcrepo-oaipmh:latest
+```
+
+If you created a `.env` file (see [Configuration](#configuration)), you 
+can run the Docker image using that file.
+
+```bash
+docker run -d -p 5000:5000 \
+    --env-file .env \
+    docker.lib.umd.edu/fcrepo-oaipmh:latest
+```
+
+Note: To refer to services running on the host machine (e.g., Solr) in the 
+configuration, you will need to use the hostname `host.docker.internal`
+instead of `localhost`.
 
 [OAI-PMH]: https://www.openarchives.org/pmh/
 [pytest]: https://docs.pytest.org/en/7.3.x/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "python-dotenv",
     "requests",
     "requests-jwtauth@git+https://github.com/umd-lib/requests-jwtauth.git@1.0.0",
+    "waitress",
 ]
 [project.optional-dependencies]
 test = [
@@ -16,3 +17,5 @@ test = [
     "pytest",
     "pytest-cov",
 ]
+[project.scripts]
+fcrepo-oaipmh-server = "oaipmh.server:run"

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,5 +25,6 @@ requests-jwtauth @ git+https://github.com/umd-lib/requests-jwtauth.git@1.0.0
 six==1.16.0
 urllib3==2.0.2
 validators==0.20.0
+waitress==2.1.2
 Werkzeug==2.3.4
 wrapt==1.15.0

--- a/src/oaipmh/__init__.py
+++ b/src/oaipmh/__init__.py
@@ -1,0 +1,4 @@
+import importlib.metadata
+
+__version__ = importlib.metadata.version('umd-fcrepo-oaipmh')
+

--- a/src/oaipmh/server.py
+++ b/src/oaipmh/server.py
@@ -1,0 +1,33 @@
+import logging
+import os
+
+import click
+import pysolr
+from dotenv import load_dotenv
+from waitress import serve
+
+from oaipmh import __version__
+from oaipmh.web import create_app
+
+load_dotenv()
+logger = logging.getLogger(__name__)
+
+
+@click.command()
+@click.option(
+    '--listen',
+    default='0.0.0.0:5000',
+    help='Address and port to listen on. Default is "0.0.0.0:5000".',
+    metavar='[ADDRESS]:PORT',
+)
+@click.version_option(__version__, '--version', '-V')
+@click.help_option('--help', '-h')
+def run(listen):
+    server_identity = f'umd-fcrepo-oaipmh/{__version__}'
+    logger.info(f'Starting {server_identity}')
+    try:
+        app = create_app()
+        serve(app, listen=listen, ident=server_identity)
+    except (OSError, RuntimeError) as e:
+        logger.error(f'Exiting: {e}')
+        raise SystemExit(1) from e

--- a/src/oaipmh/web.py
+++ b/src/oaipmh/web.py
@@ -46,7 +46,7 @@ def create_app() -> Flask:
             # An API call timed out or returned a non-200 HTTP code.
             # Log the failure and abort with server HTTP 503.
             app.logger.error(f'Upstream error: {e}')
-            abort(HTTPStatus.SERVICE_UNAVAILABLE)
+            abort(HTTPStatus.SERVICE_UNAVAILABLE, str(e))
         except OAIRepoInternalException as e:
             # There is a fault in how the DataInterface was implemented.
             # Log the failure and abort with server HTTP 500.

--- a/src/oaipmh/web.py
+++ b/src/oaipmh/web.py
@@ -8,9 +8,14 @@ from oai_repo.response import OAIResponse
 
 from oaipmh.dataprovider import DataProvider
 
-app = Flask(__name__)
 
-SOLR_URL = os.environ.get('SOLR_URL')
+def get_solr_client():
+    try:
+        solr_url = os.environ['SOLR_URL']
+    except KeyError as e:
+        raise RuntimeError(f'Missing environment variable {e}')
+
+    return pysolr.Solr(solr_url)
 
 
 def status(response: OAIResponse) -> int:
@@ -27,20 +32,27 @@ def status(response: OAIResponse) -> int:
             return HTTPStatus.BAD_REQUEST
 
 
-@app.route('/oai')
-def endpoint():
-    try:
-        repo = OAIRepository(DataProvider(solr_client=pysolr.Solr(SOLR_URL)))
-        response = repo.process(request.args.copy())
-    except OAIRepoExternalException as e:
-        # An API call timed out or returned a non-200 HTTP code.
-        # Log the failure and abort with server HTTP 503.
-        app.logger.error(f'Upstream error: {e}')
-        abort(HTTPStatus.SERVICE_UNAVAILABLE)
-    except OAIRepoInternalException as e:
-        # There is a fault in how the DataInterface was implemented.
-        # Log the failure and abort with server HTTP 500.
-        app.logger.error(f'Internal error: {e}')
-        abort(HTTPStatus.INTERNAL_SERVER_ERROR)
-    else:
-        return bytes(response).decode(), status(response), {'Content-Type': 'application/xml'}
+def create_app() -> Flask:
+    app = Flask(__name__)
+    solr_client = get_solr_client()
+    app.logger.info(f'Solr URL is {solr_client.url}')
+
+    @app.route('/oai')
+    def endpoint():
+        try:
+            repo = OAIRepository(DataProvider(solr_client=solr_client))
+            response = repo.process(request.args.copy())
+        except OAIRepoExternalException as e:
+            # An API call timed out or returned a non-200 HTTP code.
+            # Log the failure and abort with server HTTP 503.
+            app.logger.error(f'Upstream error: {e}')
+            abort(HTTPStatus.SERVICE_UNAVAILABLE)
+        except OAIRepoInternalException as e:
+            # There is a fault in how the DataInterface was implemented.
+            # Log the failure and abort with server HTTP 500.
+            app.logger.error(f'Internal error: {e}')
+            abort(HTTPStatus.INTERNAL_SERVER_ERROR)
+        else:
+            return bytes(response).decode(), status(response), {'Content-Type': 'application/xml'}
+
+    return app


### PR DESCRIPTION
- created server script using waitress
- modified the oaipmh.web module to use an app factory instead of a single instance of the Flask app
- added a version constant to the oaipmh module
- added landing page at the application root
- provides the application and repository name, a link to the Identify verb, and a link to the OAI-PMH spec
- only instantiate the DataProvider once when creating the app
- made the DataProvider.sets attribute into a property so it only connects to Solr when needed
- catch Solr errors in get_collection_titles() and re-raise as OAIRepoExternalExceptions
- include the error message when sending a "503 Service Unavailable" response
- updated README

https://issues.umd.edu/browse/LIBFCREPO-1139