### PR TITLE
LIBFCREPO-1158. Implement list_set_specs() for a given identifier.

### DIFF
--- a/src/oaipmh/dataprovider.py
+++ b/src/oaipmh/dataprovider.py
@@ -81,7 +81,8 @@ class DataProvider(DataInterface):
         :param identifier: OAI identifier string ("oai:...")
         :return: URI string
         """
-        return self.index.get_doc(identifier)[self.index.uri_field]
+        handle = OAIIdentifier.parse(identifier).local_identifier
+        return self.index.get_doc(handle)[self.index.uri_field]
 
     def get_last_modified(self, identifier: str) -> datetime:
         """
@@ -90,7 +91,8 @@ class DataProvider(DataInterface):
         :param identifier: OAI identifier string ("oai:...")
         :return: datetime object
         """
-        last_modified = self.index.get_doc(identifier)[self.index.last_modified_field]
+        handle = OAIIdentifier.parse(identifier).local_identifier
+        last_modified = self.index.get_doc(handle)[self.index.last_modified_field]
         return datetime.fromisoformat(last_modified)
 
     def transform(self, target_format: str, xml_root: _Element) -> _Element:
@@ -151,8 +153,12 @@ class DataProvider(DataInterface):
         return []
 
     def list_set_specs(self, identifier: str = None, cursor: int = 0) -> tuple:
-        sets = [Set(spec=s['spec'], name=s['name'], description=[]) for s in self.index.get_sets().values()]
-        return sets, len(sets), None
+        if identifier:
+            oai_id = OAIIdentifier.parse(identifier)
+            set_specs = self.index.get_sets_for_handle(oai_id.local_identifier)
+        else:
+            set_specs = self.index.get_sets().keys()
+        return set_specs, len(set_specs), None
 
     def get_set(self, setspec: str) -> Set:
         set_conf = self.index.get_set(setspec)

--- a/tests/dataprovider/test_dataprovider.py
+++ b/tests/dataprovider/test_dataprovider.py
@@ -1,9 +1,8 @@
 from unittest.mock import MagicMock
 
-import pysolr
 import pytest
 from lxml import etree
-from oai_repo import Set
+from oai_repo import Set, RecordHeader
 from oai_repo.exceptions import OAIErrorCannotDisseminateFormat, OAIRepoExternalException
 
 from oaipmh.dataprovider import DataProvider
@@ -124,14 +123,6 @@ def test_handle_not_found(provider):
         provider.get_record_header('oai:fcrepo:foo')
 
 
-class MockSolrResults:
-    docs = [
-    ]
-
-    def __iter__(self):
-        return iter(self.docs)
-
-
 def test_get_record_header(mock_solr_client):
     mock_index = Index(config=DEFAULT_SOLR_CONFIG, solr_client=mock_solr_client)
     mock_index.get_doc = MagicMock(
@@ -142,6 +133,7 @@ def test_get_record_header(mock_solr_client):
     )
     provider = DataProvider(index=mock_index)
     header = provider.get_record_header('oai:fcrepo:foo')
+    assert isinstance(header, RecordHeader)
     assert header.identifier == 'oai:fcrepo:foo'
     assert header.datestamp == '2023-06-16T08:37:29Z'
 
@@ -161,7 +153,7 @@ def test_list_set_specs(index_with_defaults):
     })
     provider = DataProvider(index=index_with_defaults)
     sets, length, _ = provider.list_set_specs()
-    assert all(isinstance(s, Set) for s in sets)
+    assert sets == {'foo', 'bar'}
     assert length == 2
 
 
@@ -180,6 +172,7 @@ def test_get_sets(index_with_defaults):
     })
     provider = DataProvider(index=index_with_defaults)
     oai_set = provider.get_set('bar')
+    assert isinstance(oai_set, Set)
     assert oai_set.spec == 'bar'
     assert oai_set.name == 'Bar'
     assert oai_set.description == []


### PR DESCRIPTION
- Changed the parameters of the Index methods to always take handles
- Fixed a typing error where list_set_specs was returning a list of Set objects instead of strings

https://issues.umd.edu/browse/LIBFCREPO-1158