### PR TITLE
LIBFCREPO-1138: Creating Integration Tests Using Sickle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "requests",
     "requests-jwtauth@git+https://github.com/umd-lib/requests-jwtauth.git@1.0.0",
     "waitress",
+    "Sickle"
 ]
 [project.optional-dependencies]
 test = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,9 @@ import pysolr
 import pytest
 
 
+collect_ignore = ["test_harvester.py"]
+
+
 @pytest.fixture
 def mock_solr_client():
     mock_solr = MagicMock(spec=pysolr.Solr)

--- a/tests/test_harvester.py
+++ b/tests/test_harvester.py
@@ -1,0 +1,30 @@
+import pytest
+from sickle import Sickle
+
+
+sickle = Sickle("http://localhost:5000/oai/api")
+
+
+def test_identity():
+    identity = sickle.Identify()
+    assert identity.repositoryName == 'UMD Libraries'
+    assert identity.baseURL == 'http://localhost:5000/oai/api'
+    assert identity.protocolVersion == '2.0'
+    assert identity.adminEmail == 'test@umd.edu'
+    assert identity.earliestDatestamp == '2014-01-01'
+    assert identity.granularity == 'YYYY-MM-DD'
+
+
+def test_metadata_formats():
+    metadata_formats = sickle.ListMetadataFormats()
+    assert sum(1 for _ in metadata_formats) == 2
+
+    # Used up the iterator so calling it again
+    metadata_formats = sickle.ListMetadataFormats()
+
+    for format in metadata_formats:
+        assert format.metadataPrefix == 'rdf' or format.metadataPrefix == 'oai_dc'
+        assert format.metadataNamespace == 'http://www.w3.org/1999/02/22-rdf-syntax-ns#' or \
+               format.metadataNamespace == 'http://www.openarchives.org/OAI/2.0/oai_dc/'
+        assert format.schema == 'http://www.openarchives.org/OAI/2.0/rdf.xsd' or \
+               format.schema == 'http://www.openarchives.org/OAI/2.0/oai_dc.xsd'


### PR DESCRIPTION
These tests verify the identity and the supported metadata formats of the oaipmh server and use the [Sickle](https://sickle.readthedocs.io/en/latest/index.html) library for harvesting.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1138