### PR TITLE
LIBFCREPO-1172: Updating the handle outputted in the csv

### DIFF
--- a/src/oaipmh/add_handles.py
+++ b/src/oaipmh/add_handles.py
@@ -71,12 +71,14 @@ def create_handles(reader: DictReader, config: dict) -> list:
             public_url = config['PUBLIC_BASE_URL'] + item_uuid + f"?relpath={relpath}"
 
             # Send http Request to Umd-Handle-API to mint handle
-            handle = mint_handle(config,
-                                 prefix='1903.1',
-                                 url=public_url,
-                                 repo='fcrepo',
-                                 repo_id=fcrepo_path
-                                 )
+            handle_url = mint_handle(config,
+                                     prefix='1903.1',
+                                     url=public_url,
+                                     repo='fcrepo',
+                                     repo_id=fcrepo_path
+                                     )
+
+            handle = extract_prefix_suffix(handle_url=handle_url)
 
             # Store handle
             row['Handle'] = handle
@@ -99,6 +101,12 @@ def extract_from_path(fcrepo_path: str) -> tuple[str, str]:
     return relpath, item_uuid
 
 
+def extract_prefix_suffix(handle_url: str) -> str:
+    url_pattern = r'^(http|https):\/\/.[^\/]*\/'
+
+    return re.sub(url_pattern, 'hdl:', handle_url)
+
+
 def mint_handle(config: dict, **json) -> str:
     endpoint = '/handles'
     headers = {'Authorization': f'Bearer {config["AUTH"]}'}
@@ -107,8 +115,6 @@ def mint_handle(config: dict, **json) -> str:
     if response.status_code != 200:
         raise RequestFailure(f"Got a {response.status_code} error code, check the configuration file.")
 
-    handle = response.json().get('handle_url')
+    handle_url = response.json().get('handle_url')
 
-    url_pattern = r'^(http|https):\/\/[a-z|.|-]*\/'
-
-    return re.sub(url_pattern, 'hdl:', handle)
+    return handle_url

--- a/src/oaipmh/add_handles.py
+++ b/src/oaipmh/add_handles.py
@@ -109,4 +109,6 @@ def mint_handle(config: dict, **json) -> str:
 
     handle = response.json().get('handle_url')
 
-    return handle
+    url_pattern = r'^(http|https):\/\/[a-z|.|-]*\/'
+
+    return re.sub(url_pattern, 'hdl:', handle)

--- a/tests/handles/test_handles.py
+++ b/tests/handles/test_handles.py
@@ -1,6 +1,6 @@
 import pytest
 
-from oaipmh.add_handles import extract_from_path
+from oaipmh.add_handles import extract_from_path, extract_prefix_suffix
 
 
 @pytest.mark.parametrize(
@@ -27,3 +27,21 @@ def test_extract(fcrepo_path, expected_relpath, expected_uuid):
 def test_extract_failure():
     with pytest.raises(RuntimeError):
         extract_from_path('/foo/bar/no/pairtree')
+
+
+@pytest.mark.parametrize(
+        ('handle_url', 'expected_handle'),
+        [
+            (
+                'http://hdl-local.lib.umd.edu/1903.1/329',
+                'hdl:1903.1/329'
+            ),
+            (
+                'https://hdl-local.lib.umd.edu/1903.1/330',
+                'hdl:1903.1/330'
+            )
+        ]
+)
+def test_extract_handle(handle_url, expected_handle):
+    handle = extract_prefix_suffix(handle_url=handle_url)
+    assert expected_handle == handle


### PR DESCRIPTION
Instead of the handle outputted to the csv being this:
http://hdl-local.lib.umd.edu/1903.1/329

The handle written to the csv will be now this:
hdl:1903.1/329

https://umd-dit.atlassian.net/browse/LIBFCREPO-1172