### PR TITLE
LIBFCREPO-1163. Changed 'CMD' to 'ENTRYPOINT' in the Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN pip install -r requirements.txt
 COPY src pyproject.toml /opt/umd-fcrepo-oaipmh/
 RUN pip install -e .
 
-CMD ["fcrepo-oaipmh-server"]
+ENTRYPOINT ["fcrepo-oaipmh-server"]

--- a/src/oaipmh/solr.py
+++ b/src/oaipmh/solr.py
@@ -27,6 +27,7 @@ class Index:
         self.solr = solr_client
         logger.info(f'Solr URL: {self.solr.url}')
         logger.debug(f'Index configuration: {config}')
+        logger.debug(f'All sets: {self.get_sets()}')
 
     @property
     def auto_create_sets(self):


### PR DESCRIPTION
Thus the Docker image will always run the fcrepo-oaipmh-server command when started. Also added a debugging log message listing the all the sets found at server startup.

https://issues.umd.edu/browse/LIBFCREPO-1163