### PR TITLE
LIBFCREPO1174: Adding check for BASE_URL and swapping / for : in relpath

### DIFF
--- a/src/oaipmh/__init__.py
+++ b/src/oaipmh/__init__.py
@@ -1,4 +1,3 @@
 import importlib.metadata
 
 __version__ = importlib.metadata.version('umd-fcrepo-oaipmh')
-

--- a/src/oaipmh/add_handles.py
+++ b/src/oaipmh/add_handles.py
@@ -62,7 +62,7 @@ def create_handles(reader: DictReader, config: dict) -> list:
     exports = []
     for row in reader:
         if 'Handle' not in row or row['Handle'] is None:
-            if row['URI'].startswith(config['BASE_URL']) is False:
+            if not row['URI'].startswith(config['BASE_URL']):
                 logger.warning(f"The URI ({row['URI']}) does not start with the BASE_URL ({config['BASE_URL']})")
                 logger.warning("Skipping creating a handle for this URI")
                 exports.append(row)

--- a/src/oaipmh/add_handles.py
+++ b/src/oaipmh/add_handles.py
@@ -62,10 +62,17 @@ def create_handles(reader: DictReader, config: dict) -> list:
     exports = []
     for row in reader:
         if 'Handle' not in row or row['Handle'] is None:
+            if row['URI'].startswith(config['BASE_URL']) is False:
+                logger.warning(f"The URI ({row['URI']}) does not start with the BASE_URL ({config['BASE_URL']})")
+                logger.warning("Skipping creating a handle for this URI")
+                exports.append(row)
+                continue
+
             fcrepo_path = row['URI'].replace(config['BASE_URL'], '')
 
             # extract relpath and uuid from fcrepo path
             relpath, item_uuid = extract_from_path(fcrepo_path)
+            relpath = relpath.replace('/', ':')
 
             # create url for http request
             public_url = config['PUBLIC_BASE_URL'] + item_uuid + f"?relpath={relpath}"

--- a/src/oaipmh/dataprovider.py
+++ b/src/oaipmh/dataprovider.py
@@ -65,7 +65,7 @@ class DataProvider(DataInterface):
     def get_oai_identifier(self, handle: str) -> OAIIdentifier:
         """
         Given a handle, return a full OAI identifier.
-        
+
         :param handle: resource handle, e.g. "1903.1/12345"
         :return: OAI Identifier
         """


### PR DESCRIPTION
URI's that dont start with the BASE_URL in the config won't have handles generated for them, and when the relpath is obtained from the fcrepo path, the / from the fcrepo path are replaced with :

https://umd-dit.atlassian.net/browse/LIBFCREPO-1174