### PR TITLE
LIBFCREPO-1168: Adding support for HTTP Proxy URL for Handles

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ FCREPO_JWT_TOKEN=...
 SOLR_URL=...
 # enable debugging and hot reloading when run via "flask run"
 FLASK_DEBUG=1
+# HTTP Proxy for the minted handles
+# e.g (https://hdl.handle.net/)
+# Don't forget to include the / at the end
+HANDLE_PROXY_PREFIX=...
 ```
 
 And create a `solr_conf.yml` file with the following contents:

--- a/src/oaipmh/dataprovider.py
+++ b/src/oaipmh/dataprovider.py
@@ -54,6 +54,7 @@ class DataProvider(DataInterface):
     oai_repository_name = EnvAttribute('OAI_REPOSITORY_NAME')
     oai_namespace_identifier = EnvAttribute('OAI_NAMESPACE_IDENTIFIER')
     report_deleted_records = EnvAttribute('REPORT_DELETED_RECORDS', 'no')
+    handle_proxy_prefix = EnvAttribute('HANDLE_PROXY_PREFIX')
     limit: int = EnvAttribute('PAGE_SIZE', 25)
 
     def __init__(self, index: Index):
@@ -111,7 +112,7 @@ class DataProvider(DataInterface):
             transform = self._transformers[target_format]
         except KeyError:
             raise OAIErrorCannotDisseminateFormat
-        return transform(xml_root)
+        return transform(xml_root, handle_proxy_prefix=f'"{self.handle_proxy_prefix}"')
 
     def get_identify(self) -> Identify:
         return Identify(

--- a/src/oaipmh/transformers/oai_dc.xsl
+++ b/src/oaipmh/transformers/oai_dc.xsl
@@ -10,6 +10,7 @@
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
   <xsl:strip-space elements="*"/>
+  <xsl:param name="handle_proxy_prefix" />
 
   <xsl:template match="text()"/>
 
@@ -52,8 +53,11 @@
 
   <!-- identifier -->
   <xsl:template match="dcterms:identifier">
-    <dc:identifier><xsl:value-of select="."/></dc:identifier>
-  </xsl:template>
+  <dc:identifier><xsl:value-of select="."/></dc:identifier>
+  <xsl:if test="starts-with(., 'hdl:')">
+    <dc:identifier><xsl:value-of select="$handle_proxy_prefix"/><xsl:value-of select="substring(., 5)"/></dc:identifier>
+  </xsl:if>
+</xsl:template>
 
   <!-- language -->
   <xsl:template match="dc:language">


### PR DESCRIPTION
There is a new environment variable, HANDLE_PROXY_PREFIX, in the .env

For handles in the server, there will be an additional identifer with the hdl: section of the handle replaced by the environment variable.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1168