### PR TITLE
LIBFCREPO-1191. Accept POST requests to the /oai/api route.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ For full configuration information, see
 To run the application in debug mode, with hot code reloading:
 
 ```bash
-flask --app "oaipmh.web:create_app(solr_config_file='solr_conf.yml')" run
+flask --app "oaipmh.web:app(solr_config_file='solr_conf.yml')" run
 ```
 
 The OAI-PMH service will be available at <http://localhost:5000/oai/api>,

--- a/src/oaipmh/dataprovider.py
+++ b/src/oaipmh/dataprovider.py
@@ -137,7 +137,7 @@ class DataProvider(DataInterface):
         return RecordHeader(
             identifier=identifier,
             datestamp=granularity_format(self.datestamp_granularity, last_modified),
-            setspecs=self.index.get_sets_for_handle(handle),
+            setspecs=list(self.index.get_sets_for_handle(handle).keys()),
         )
 
     def get_record_metadata(self, identifier: str, metadataprefix: str) -> _Element | None:

--- a/src/oaipmh/server.py
+++ b/src/oaipmh/server.py
@@ -5,9 +5,8 @@ from dotenv import load_dotenv
 from waitress import serve
 
 from oaipmh import __version__
-from oaipmh.web import create_app
+from oaipmh.web import app
 
-load_dotenv()
 logger = logging.getLogger(__name__)
 
 
@@ -26,11 +25,15 @@ logger = logging.getLogger(__name__)
 @click.version_option(__version__, '--version', '-V')
 @click.help_option('--help', '-h')
 def run(listen, solr_config_file):
+    load_dotenv()
     server_identity = f'umd-fcrepo-oaipmh/{__version__}'
     logger.info(f'Starting {server_identity}')
     try:
-        app = create_app(solr_config_file=solr_config_file)
-        serve(app, listen=listen, ident=server_identity)
+        serve(
+            app=app(solr_config_file=solr_config_file),
+            listen=listen,
+            ident=server_identity,
+        )
     except (OSError, RuntimeError) as e:
         logger.error(f'Exiting: {e}')
         raise SystemExit(1) from e

--- a/src/oaipmh/web.py
+++ b/src/oaipmh/web.py
@@ -76,7 +76,7 @@ def create_app(data_provider: DataProvider) -> Flask:
         Protocol 2.0 Specification</a> for information about how to use this service.</p>
         """
 
-    @_app.route('/oai/api')
+    @_app.route('/oai/api', methods=['GET', 'POST'])
     def endpoint():
         try:
             repo = OAIRepository(data_provider)

--- a/src/oaipmh/web.py
+++ b/src/oaipmh/web.py
@@ -80,7 +80,12 @@ def create_app(data_provider: DataProvider) -> Flask:
     def endpoint():
         try:
             repo = OAIRepository(data_provider)
-            response = repo.process(request.args.copy())
+            # combine all possible parameters to the request
+            parameters = {
+                **request.args,
+                **request.form,
+            }
+            response = repo.process(parameters)
         except OAIRepoExternalException as e:
             # An API call timed out or returned a non-200 HTTP code.
             # Log the failure and abort with server HTTP 503.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from unittest.mock import MagicMock
 
 import pysolr
@@ -7,8 +8,30 @@ import pytest
 collect_ignore = ["test_harvester.py"]
 
 
+class MockSolrResult:
+    @property
+    def hits(self):
+        return len(list(self))
+
+    @property
+    def docs(self):
+        return list(self)
+
+    def __iter__(self):
+        return iter([
+            {'handle': '1903.1/sample1', 'last_modified': str(datetime.now())},
+            {'handle': '1903.1/sample2', 'last_modified': str(datetime.now())},
+            {'handle': '1903.1/sample3', 'last_modified': str(datetime.now())},
+        ])
+
+
 @pytest.fixture
 def mock_solr_client():
     mock_solr = MagicMock(spec=pysolr.Solr)
     mock_solr.url = 'http://localhost:8983/solr/fcrepo'
     return mock_solr
+
+
+@pytest.fixture
+def mock_solr_result():
+    return MockSolrResult()

--- a/tests/dataprovider/test_dataprovider.py
+++ b/tests/dataprovider/test_dataprovider.py
@@ -228,22 +228,9 @@ def test_get_record_metadata_not_found(provider):
     assert str(e.value) == 'Unable to retrieve resource from fcrepo'
 
 
-class MockSolrResult:
-    @property
-    def hits(self):
-        return len(list(self))
-
-    def __iter__(self):
-        return iter([
-            {'handle': '1903.1/sample1'},
-            {'handle': '1903.1/sample2'},
-            {'handle': '1903.1/sample3'},
-        ])
-
-
-def test_list_identifiers(monkeypatch, provider, mock_solr_client):
+def test_list_identifiers(monkeypatch, provider, mock_solr_client, mock_solr_result):
     monkeypatch.setenv('OAI_NAMESPACE_IDENTIFIER', 'fcrepo')
-    mock_solr_client.search = MagicMock(return_value=MockSolrResult())
+    mock_solr_client.search = MagicMock(return_value=mock_solr_result)
     identifiers, hits, _ = provider.list_identifiers(metadataprefix='oai_dc')
     assert hits == 3
     assert identifiers == [

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,129 @@
+from unittest.mock import MagicMock
+
+import pytest
+from oai_repo.response import OAIResponse
+
+from oaipmh.dataprovider import DataProvider
+from oaipmh.solr import Index, DEFAULT_SOLR_CONFIG
+from oaipmh.web import create_app, get_config, status
+
+
+@pytest.fixture
+def data_provider(monkeypatch, mock_solr_client, mock_solr_result):
+    monkeypatch.setenv('ADMIN_EMAIL', 'peichman@umd.edu')
+    monkeypatch.setenv('BASE_URL', 'http://localhost:5000/oai/api')
+    monkeypatch.setenv('OAI_NAMESPACE_IDENTIFIER', 'fcrepo-local')
+    monkeypatch.setenv('OAI_REPOSITORY_NAME', 'UMD Libraries')
+    monkeypatch.setenv('DATESTAMP_GRANULARITY', 'YYYY-MM-DD')
+    monkeypatch.setenv('EARLIEST_DATESTAMP', '2014-01-01')
+    mock_solr_client.search = MagicMock(return_value=mock_solr_result)
+    return DataProvider(
+        Index(
+            config=DEFAULT_SOLR_CONFIG,
+            solr_client=mock_solr_client,
+        )
+    )
+
+
+@pytest.fixture
+def sample_config(datadir):
+    return {
+        'base_query': 'hdl:*',
+        'handle_field': 'hdl',
+        'uri_field': 'id',
+        'last_modified_field': 'last_modified',
+        'auto_create_sets': False,
+        'sets': [],
+    }
+
+
+def test_status_ok():
+    oai_response = MagicMock(spec=OAIResponse)
+    oai_response.__bool__.return_value = True
+    assert status(oai_response) == 200
+
+
+def test_status_not_found():
+    mock_error = MagicMock()
+    mock_error.get.return_value = 'noRecordsMatch'
+    oai_response = MagicMock(spec=OAIResponse)
+    oai_response.__bool__.return_value = False
+    oai_response.xpath.return_value = [mock_error]
+    assert status(oai_response) == 404
+
+
+def test_status_bad_request():
+    mock_error = MagicMock()
+    mock_error.get.return_value = 'otherError'
+    oai_response = MagicMock(spec=OAIResponse)
+    oai_response.__bool__.return_value = False
+    oai_response.xpath.return_value = [mock_error]
+    assert status(oai_response) == 400
+
+
+def test_get_config_default():
+    assert get_config(None) == DEFAULT_SOLR_CONFIG
+
+
+def test_get_config_from_filename(datadir, sample_config):
+    assert get_config(str(datadir / 'config.yml')) == sample_config
+
+
+def test_get_config_from_file(datadir, sample_config):
+    with (datadir / 'config.yml').open() as fh:
+        assert get_config(fh) == sample_config
+
+
+def test_home(data_provider):
+    app = create_app(data_provider)
+    app_client = app.test_client()
+    response = app_client.get('/oai')
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    ('http_method',),
+    [['get'], ['post']],
+)
+def test_identify(http_method, data_provider):
+    app = create_app(data_provider=data_provider)
+    app_client = app.test_client()
+    request = getattr(app_client, http_method)
+    response = request('/oai/api?verb=Identify')
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    ('http_method',),
+    [['get'], ['post']],
+)
+def test_list_sets(http_method, data_provider):
+    app = create_app(data_provider=data_provider)
+    app_client = app.test_client()
+    request = getattr(app_client, http_method)
+    response = request('/oai/api?verb=ListSets')
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    ('http_method',),
+    [['get'], ['post']],
+)
+def test_list_metadata_formats(http_method, data_provider):
+    app = create_app(data_provider=data_provider)
+    app_client = app.test_client()
+    request = getattr(app_client, http_method)
+    response = request('/oai/api?verb=ListMetadataFormats')
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    ('http_method',),
+    [['get'], ['post']],
+)
+def test_list_identifiers(http_method, data_provider):
+    app = create_app(data_provider=data_provider)
+    app_client = app.test_client()
+    request = getattr(app_client, http_method)
+    response = request('/oai/api?verb=ListIdentifiers&metadataPrefix=oai_dc')
+    assert response.status_code == 200

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -74,6 +74,13 @@ def test_get_config_from_file(datadir, sample_config):
         assert get_config(fh) == sample_config
 
 
+def test_root(data_provider):
+    app = create_app(data_provider)
+    app_client = app.test_client()
+    response = app_client.get('/')
+    assert response.status_code == 302
+
+
 def test_home(data_provider):
     app = create_app(data_provider)
     app_client = app.test_client()
@@ -82,48 +89,32 @@ def test_home(data_provider):
 
 
 @pytest.mark.parametrize(
-    ('http_method',),
-    [['get'], ['post']],
+    ('verb', 'parameters'),
+    [
+        ['Identify', {}],
+        ['ListSets', {}],
+        ['ListMetadataFormats', {}],
+        ['ListIdentifiers', {'metadataPrefix': 'oai_dc'}],
+    ]
 )
-def test_identify(http_method, data_provider):
+def test_oai_get(data_provider, verb, parameters):
     app = create_app(data_provider=data_provider)
     app_client = app.test_client()
-    request = getattr(app_client, http_method)
-    response = request('/oai/api?verb=Identify')
+    response = app_client.get('/oai/api', query_string={'verb': verb, **parameters})
     assert response.status_code == 200
 
 
 @pytest.mark.parametrize(
-    ('http_method',),
-    [['get'], ['post']],
+    ('verb', 'parameters'),
+    [
+        ['Identify', {}],
+        ['ListSets', {}],
+        ['ListMetadataFormats', {}],
+        ['ListIdentifiers', {'metadataPrefix': 'oai_dc'}],
+    ]
 )
-def test_list_sets(http_method, data_provider):
+def test_oai_post(data_provider, verb, parameters):
     app = create_app(data_provider=data_provider)
     app_client = app.test_client()
-    request = getattr(app_client, http_method)
-    response = request('/oai/api?verb=ListSets')
-    assert response.status_code == 200
-
-
-@pytest.mark.parametrize(
-    ('http_method',),
-    [['get'], ['post']],
-)
-def test_list_metadata_formats(http_method, data_provider):
-    app = create_app(data_provider=data_provider)
-    app_client = app.test_client()
-    request = getattr(app_client, http_method)
-    response = request('/oai/api?verb=ListMetadataFormats')
-    assert response.status_code == 200
-
-
-@pytest.mark.parametrize(
-    ('http_method',),
-    [['get'], ['post']],
-)
-def test_list_identifiers(http_method, data_provider):
-    app = create_app(data_provider=data_provider)
-    app_client = app.test_client()
-    request = getattr(app_client, http_method)
-    response = request('/oai/api?verb=ListIdentifiers&metadataPrefix=oai_dc')
+    response = app_client.post('/oai/api', data={'verb': verb, **parameters})
     assert response.status_code == 200

--- a/tests/test_web/config.yml
+++ b/tests/test_web/config.yml
@@ -1,0 +1,6 @@
+base_query: hdl:*
+handle_field: hdl
+uri_field: id
+last_modified_field: last_modified
+auto_create_sets: False
+sets: []


### PR DESCRIPTION
Also split create_app into two functions for easier testing:
- create_app() takes a DataProvider instance directly; this is used in the tests where we need to mock the Solr index
- app() takes a Solr config file, and reads the SOLR_URL from the environment, so we have an easy way to run the Flask app from the command line
- added tests for the webapp

https://umd-dit.atlassian.net/browse/LIBFCREPO-1191