### PR TITLE
LIBAVALON-306: Making DataProvider configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ FLASK_DEBUG=1
 # e.g (https://hdl.handle.net/)
 # Don't forget to include the / at the end
 HANDLE_PROXY_PREFIX=...
+# Type of Dataprovider (Fedora, Avalon)
+DATA_PROVIDER_TYPE=...
 ```
 
 And create a `solr_conf.yml` file with the following contents:
@@ -79,7 +81,7 @@ For full configuration information, see
 To run the application in debug mode, with hot code reloading:
 
 ```bash
-flask --app "oaipmh.web:app(solr_config_file='solr_conf.yml')" run
+flask --app "oaipmh.web:app(solr_config_file='solr_conf.yml', data_provider_type='Fedora')" run
 ```
 
 The OAI-PMH service will be available at <http://localhost:5000/oai/api>,
@@ -97,7 +99,7 @@ And add `-p {port number}` to the `flask` command:
 
 ```bash
 # for example, to run on port 8000
-flask --app "oaipmh.web:create_app(solr_config_file='solr_conf.yml')" run -p 8000
+flask --app "oaipmh.web:create_app(solr_config_file='solr_conf.yml', data_provider_type='Fedora')" run -p 8000
 ```
 
 ### Testing

--- a/src/oaipmh/dataprovider.py
+++ b/src/oaipmh/dataprovider.py
@@ -3,6 +3,7 @@ import os
 from dataclasses import MISSING
 from datetime import datetime
 from typing import Optional, Any
+from enum import Enum
 
 from lxml import etree
 # noinspection PyProtectedMember
@@ -193,3 +194,7 @@ class FedoraDataProvider(DataProvider):
         else:
             logger.error(f'GET {uri} -> {response.status_code} {response.reason}')
             raise OAIRepoExternalException('Unable to retrieve resource from fcrepo')
+
+
+class DataProviderType(Enum):
+    Fedora = FedoraDataProvider

--- a/src/oaipmh/server.py
+++ b/src/oaipmh/server.py
@@ -1,4 +1,5 @@
 import logging
+from os import environ
 
 import click
 from dotenv import load_dotenv
@@ -30,7 +31,7 @@ def run(listen, solr_config_file):
     logger.info(f'Starting {server_identity}')
     try:
         serve(
-            app=app(solr_config_file=solr_config_file),
+            app=app(solr_config_file=solr_config_file, data_provider_type=environ['DATA_PROVIDER_TYPE']),
             listen=listen,
             ident=server_identity,
         )

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 from oai_repo.response import OAIResponse
 
-from oaipmh.dataprovider import DataProvider
+from oaipmh.dataprovider import DataProvider, DataProviderType
 from oaipmh.solr import Index, DEFAULT_SOLR_CONFIG
 from oaipmh.web import create_app, get_config, status
 
@@ -118,3 +118,20 @@ def test_oai_post(data_provider, verb, parameters):
     app_client = app.test_client()
     response = app_client.post('/oai/api', data={'verb': verb, **parameters})
     assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    ('data_provider_type'),
+    ['Fedora']
+)
+def test_dataprovider_enum_valid(data_provider_type):
+    assert DataProviderType[data_provider_type] is not None
+
+
+@pytest.mark.parametrize(
+    ('data_provider_type'),
+    ['Fedoraa', 'asdf', 'not_a_valid_provider']
+)
+def test_dataprovider_enum_invalid(data_provider_type):
+    with pytest.raises(KeyError):
+        DataProviderType[data_provider_type]


### PR DESCRIPTION
Created an Enum class that currently maps just Fedora to the FedoraDataProvider class, this would be accessed in the call to app, where the it would be retrieved by using the data_provider_type, and would throw a runtime error if the data_provider_type isn't found.

https://umd-dit.atlassian.net/browse/LIBAVALON-306